### PR TITLE
Use packaged mode to serve dashboard & daemon on the same host

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,11 @@
+:8080 {
+	handle_path /api/* {
+		reverse_proxy http://localhost:9090
+	}
+
+  handle {
+    file_server
+    root * /usr/share/caddy/html
+    try_files {path} /index.html
+  }
+} 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/dashboard:v0.1.36@sha256:57bc9a2d1a4db7dfe4208de6bbec9edbfaad69133ef80c788a984466b9ebbc90 as builder
+FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/dashboard:v0.1.43@sha256:55f482c26bf2f5907dde9ce8309fa8c183cedac5f4028924099ab85e85f22a53 as builder
 
-FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/tdexd:v0.8.17@sha256:10c648982648c71c7c31456c1fc64a3f5c03763a1879cc926e321cd6081c2415
+FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/tdexd:v0.8.19@sha256:5a2c0db9f74812e67aa98f50f396e81edd23ef49cb6797b084027ba6124db707
 
+## Dashaboard 
+##
 ENV USE_PROXY "false"
 ENV IS_PACKAGED "true"
-ENV TDEX_DAEMON_URL "tdex.embassy:9090"
 
+## Daemon 
+##
 ENV TDEX_LOG_LEVEL 5
 ENV TDEX_EXPLORER_ENDPOINT https://liquid.network/liquid/api
 ENV TDEX_OPERATOR_LISTENING_PORT 9090
 ENV TDEX_TRADE_LISTENING_PORT  9090
 ENV TDEX_NO_OPERATOR_TLS "true"
-ENV TDEX_CONNECT_ADDR "tdex.embassy:9090"
 ENV TDEX_CONNECT_PROTO http
 
 USER root
@@ -20,6 +22,7 @@ RUN apt-get update && apt-get install -y tini wget
 RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.2/yq_linux_arm.tar.gz -O - |\
     tar xz && mv yq_linux_arm /usr/bin/yq
 
+
 RUN mkdir -p /patch/
 RUN mkdir -p /usr/share/caddy/
 RUN mkdir -p /root/.tdex-daemon/
@@ -27,9 +30,10 @@ RUN mkdir -p /root/.tdex-daemon/
 COPY --from=builder /patch/web-entrypoint.sh /patch/web-entrypoint.sh
 COPY --from=builder /usr/share/caddy/ /usr/share/caddy/
 COPY --from=builder /usr//bin/caddy /usr//bin/caddy
-COPY --from=builder /etc/caddy/ /etc/caddy/
 COPY --from=builder /config/caddy/ /config/caddy/
 COPY --from=builder /data/caddy/ /data/caddy/
+# Override the Caddyfile of the dashaboard image  
+ADD Caddyfile /etc/caddy/Caddyfile
 
 ADD docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
 RUN chmod a+x /usr/local/bin/docker_entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/dashboard:v0.1.36@sha256:57b
 
 FROM --platform=linux/arm64/v8 ghcr.io/tdex-network/tdexd:v0.8.17@sha256:10c648982648c71c7c31456c1fc64a3f5c03763a1879cc926e321cd6081c2415
 
-ENV USE_PROXY "true"
+ENV USE_PROXY "false"
 ENV IS_PACKAGED "true"
 ENV TDEX_DAEMON_URL "tdex.embassy:9090"
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:
 	rm -f $(ID_NAME).s9pk
 	rm -f scripts/*.js
 
-$(ID_NAME).s9pk: manifest.yaml instructions.md icon.svg LICENSE scripts/embassy.js image.tar
+$(ID_NAME).s9pk: manifest.yaml instructions.md icon.svg LICENSE scripts/embassy.js image.tar Caddyfile
 	embassy-sdk pack
 
 image.tar: Dockerfile docker_entrypoint.sh 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -ex
+set -e
 # turn on bash's job control
 set -m
   

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,13 +1,25 @@
 #!/bin/sh
 
-set -e
-
-export TDEX_DAEMON_URL=$(yq e '.tor-address' /root/start9/config.yaml):9090
+set -ex
+# turn on bash's job control
+set -m
+  
+export TRADER_HIDDEN_SERVICE=$(yq e '.tor-address' /root/start9/config.yaml):9090
 export TDEX_CONNECT_ADDR=$(yq e '.tor-address' /root/start9/config.yaml):9090
 
+# Start the primary process and put it in the background
 echo 'Starting TDEX Daemon...'
 tdexd &
-
+  
+# Start the helper process
 echo 'Starting TDEX Dashboard...'
 ../patch/web-entrypoint.sh
 exec tini -p SIGTERM -- caddy run --config /etc/caddy/Caddyfile --adapter caddyfile 
+
+  
+# the my_helper_process might need to know how to wait on the
+# primary process to start before it does its work and returns
+  
+# now we bring the primary process back into the foreground
+# and leave it there
+fg %1


### PR DESCRIPTION
## What's Changed?

- Bump images to latest
- Reverse proxy `/api` to daemon listening on `localhost:9090`
- Override the Caddyfile of the dashboard image
- Use Caddy to both serve static files of the dashboard and the daemon listening on port 9090
- docker-entrypoint: bring back in foreground the `tdexd` process 

## How to test

```sh
# Build image
DOCKER_CLI_EXPERIMENTAL=enabled docker build -t tdex-wrapper .

# Run the image
docker run -it --name tdex -v `pwd`/tdex-data:/home/tdex/.tdex-daemon -p 9090:9090 -p 8080:8080 --entrypoint /usr/local/bin/docker_entrypoint.sh tdex-wrapper
```

